### PR TITLE
changed regex to a-z because the id can also contain more than a-f chars

### DIFF
--- a/gl-auth/auth-bbb.py
+++ b/gl-auth/auth-bbb.py
@@ -4,8 +4,8 @@ import os
 import re
 
 def parse_url(url=''):
-	r = re.compile(r'[0-9a-f]{40}-[0-9]{13}')
-	t = re.compile(r'^/presentation/[0-9a-f]{40}-[0-9]{13}/presentation/[0-9a-f]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
+	r = re.compile(r'[0-9a-z]{40}-[0-9]{13}')
+	t = re.compile(r'^/presentation/[0-9a-z]{40}-[0-9]{13}/presentation/[0-9a-z]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
 	try:
 		thumb = t.findall(url)
 		if thumb:

--- a/gl-auth/auth-passwd-bbb.py
+++ b/gl-auth/auth-passwd-bbb.py
@@ -29,8 +29,8 @@ GL_USER_SHARE_VALUE = 'false'
 
 
 def parse_url(url=''):
-	r = re.compile(r'[0-9a-f]{40}-[0-9]{13}')
-	t = re.compile(r'^/presentation/[0-9a-f]{40}-[0-9]{13}/presentation/[0-9a-f]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
+	r = re.compile(r'[0-9a-z]{40}-[0-9]{13}')
+	t = re.compile(r'^/presentation/[0-9a-z]{40}-[0-9]{13}/presentation/[0-9a-z]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
 	try:
 		thumb = t.findall(url)
 		if thumb:
@@ -76,7 +76,7 @@ def get_meeting_bbbid(meetingid, recording_path='/var/bigbluebutton/published/pr
 		metadata = open(recording_path+'/'+meetingid+'/metadata.xml', 'r')
 		for line in metadata:
 			if '<meetingId>' in line:
-				re_bbbid = re.compile(r'[a-f0-9]{40}')
+				re_bbbid = re.compile(r'[a-z0-9]{40}')
 				return re_bbbid.findall(line)[0]
 	except:
 		return False

--- a/gl-auth/auth-passwd-scalelite.py
+++ b/gl-auth/auth-passwd-scalelite.py
@@ -27,8 +27,8 @@ GL_USER_SHARE_VALUE = 'false'
 
 
 def parse_url(url=''):
-	r = re.compile(r'[0-9a-f]{40}-[0-9]{13}')
-	t = re.compile(r'^/presentation/[0-9a-f]{40}-[0-9]{13}/presentation/[0-9a-f]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
+	r = re.compile(r'[0-9a-z]{40}-[0-9]{13}')
+	t = re.compile(r'^/presentation/[0-9a-z]{40}-[0-9]{13}/presentation/[0-9a-z]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
 	try:
 		thumb = t.findall(url)
 		if thumb:

--- a/gl-auth/auth-scalelite.py
+++ b/gl-auth/auth-scalelite.py
@@ -7,8 +7,8 @@ import psycopg2
 conn = psycopg2.connect("dbname=scalelite user=postgres password=PASSWORD host=localhost")
 
 def parse_url(url=''):
-	r = re.compile(r'[0-9a-f]{40}-[0-9]{13}')
-	t = re.compile(r'^/presentation/[0-9a-f]{40}-[0-9]{13}/presentation/[0-9a-f]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
+	r = re.compile(r'[0-9a-z]{40}-[0-9]{13}')
+	t = re.compile(r'^/presentation/[0-9a-z]{40}-[0-9]{13}/presentation/[0-9a-z]{40}-[0-9]{13}/thumbnails/(thumb-[1-3].png|images/favicon.png)$')
 	try:
 		thumb = t.findall(url)
 		if thumb:


### PR DESCRIPTION
While my setup testing I came across a problem with some ids which were not correctly validated by the auth.py so I checked the regex parts and it seems that there can be more than a-f chars so I put the limit to a-z and now it works fine for me.

Is there any wiki entry which certains that a-f was correct?