### PR TITLE
solved error with some internal ids which can have more chars than a-f

### DIFF
--- a/gl-auth/auth-passwd-bbb.py
+++ b/gl-auth/auth-passwd-bbb.py
@@ -76,8 +76,8 @@ def get_meeting_bbbid(meetingid, recording_path='/var/bigbluebutton/published/pr
 		metadata = open(recording_path+'/'+meetingid+'/metadata.xml', 'r')
 		for line in metadata:
 			if '<meetingId>' in line:
-				re_bbbid = re.compile(r'[a-f0-9]{40}')
-				return re_bbbid.findall(line)[0]
+				re_internalid = re.compile(r'[a-z0-9]{40}')
+				return re_internalid.findall(line)[0]
 	except:
 		return False
 	return False


### PR DESCRIPTION
I am sorry for your inconvenience with the last pull request I did.
I will try to explain my problem and the solution more detailed now.

While my setup I came across a problem with the python script /gl-auth/auth-passwd-bbb.py
which seems to give an error at the line https://github.com/ichdasich/bbb-rec-perm/blob/master/gl-auth/auth-passwd-bbb.py#L80. This happens because we try to fetch there an entry of an empty array due the fact that the regex expression do not match my meetingid.

Here are some metadata to prove my point:
```
<?xml version='1.0' encoding='UTF-8'?>
<recording>
  <id>1b3ffdff81d8246aaf1e92b93380a67bae80589b-1594896576930</id>
  <state>published</state>
  <published>true</published>
  <start_time>1594896576930</start_time>
  <end_time>1594896607058</end_time>
  <participants>1</participants>
  <raw_size>1177235</raw_size>
  <meeting
  id="1b3ffdff81d8246aaf1e92b93380a67bae80589b-1594896576930" externalId="zgqn49igpydht6vhqk7mqoq6jeaauoa7nhy7th4t" name="Home Room" breakout="false">
</meeting>
  <meta>
    <name> Home Room </name>
    <bbb-origin-version/>
    <meetingName>Home Room</meetingName>
    <meetingId>zgqn49igpydht6vhqk7mqoq6jeaauoa7nhy7th4t</meetingId>
    <gl-listed>false</gl-listed>
    <bbb-origin>Greenlight</bbb-origin>
    <isBreakout>false</isBreakout>
    <bbb-origin-server-name>x.x.x.x</bbb-origin-server-name>
  </meta>
```

and 

```
<?xml version='1.0' encoding='UTF-8'?>
<recording>
  <id>1b3ffdff81d8246aaf1e92b93380a67bae80589b-1594896576930</id>
  <state>published</state>
  <published>true</published>
  <start_time>1594896576930</start_time>
  <end_time>1594896607058</end_time>
  <participants>1</participants>
  <raw_size>1177235</raw_size>
  <meeting
  id="1b3ffdff81d8246aaf1e92b93380a67bae80589b-1594896576930" externalId="zgqn49igpydht6vhqk7mqoq6jeaauoa7nhy7th4t" name="Home Room" breakout="false">
</meeting>
  <meta>
    <name> Home Room </name>
    <bbb-origin-version/>
    <meetingName>Home Room</meetingName>
    <meetingId>zgqn49igpydht6vhqk7mqoq6jeaauoa7nhy7th4t</meetingId>
    <gl-listed>false</gl-listed>
    <bbb-origin>Greenlight</bbb-origin>
    <isBreakout>false</isBreakout>
    <bbb-origin-server-name>x.x.x.x</bbb-origin-server-name>
  </meta>
```

I hope it is now more clear :)
